### PR TITLE
Simplify VRL_STATES by incorporating additional methods into the enum

### DIFF
--- a/src/ReplayFromResult.py
+++ b/src/ReplayFromResult.py
@@ -418,7 +418,7 @@ class Replay(VehicleMovementSimulation):
             for vid, veh_stat_f in fleet_stat_df.groupby(G_RQ_VID):
                 self.replay_vehicles[(op_id, vid)] = ReplayVehicle(op_id, vid, veh_stat_f, self.sim_start_time,
                                                                    self.sim_end_time)
-        states_codes = {v: x for x, v in G_VEHICLE_STATUS_DICT.items()}
+        states_codes = {status.display_name: status.value for status in VRL_STATES}
         self.poss_veh_states = sorted(self.poss_veh_states, key=lambda x: states_codes[x])
         print("... processing user data")
         # TODO # load vehicle data

--- a/src/evaluation/standard.py
+++ b/src/evaluation/standard.py
@@ -141,7 +141,7 @@ def avg_in_vehicle_distance(op_df):
     sum_dis = 0
     for vid, veh_df in op_df.groupby(G_V_VID):
         for status, distance, ob_str, boarding_str, alight_str in zip(veh_df[G_VR_STATUS].values, veh_df[G_VR_LEG_DISTANCE].values, veh_df[G_VR_OB_RID].values, veh_df[G_VR_BOARDING_RID].values, veh_df[G_VR_ALIGHTING_RID].values):
-            if status == G_VEHICLE_STATUS_DICT[VRL_STATES.BOARDING]:
+            if status == VRL_STATES.BOARDING.display_name:
                 if boarding_str == boarding_str:
                     for rid in boarding_str.split(";"):
                         dis_dict[rid] = 0
@@ -169,7 +169,7 @@ def shared_rides(op_df):
     N_shared = 0
     for vid, veh_df in op_df.groupby(G_V_VID):
         for status, distance, ob_str, boarding_str, alight_str in zip(veh_df[G_VR_STATUS].values, veh_df[G_VR_LEG_DISTANCE].values, veh_df[G_VR_OB_RID].values, veh_df[G_VR_BOARDING_RID].values, veh_df[G_VR_ALIGHTING_RID].values):
-            if status == G_VEHICLE_STATUS_DICT[VRL_STATES.BOARDING]:
+            if status == VRL_STATES.BOARDING.display_name:
                 if boarding_str == boarding_str:
                     for rid in boarding_str.split(";"):
                         rid_shared_dict[rid] = 0
@@ -369,11 +369,11 @@ def standard_evaluation(output_dir, evaluation_start_time = None, evaluation_end
                 # correct utilization: do not consider tasks after simulation end time
                 op_vehicle_df["VRL_end_sim_end_time"] = np.minimum(op_vehicle_df[G_VR_LEG_END_TIME], sim_end_time)
                 op_vehicle_df["VRL_start_sim_end_time"] = np.minimum(op_vehicle_df[G_VR_LEG_START_TIME], sim_end_time)
-                utilized_veh_df = op_vehicle_df[(op_vehicle_df["status"] != G_VEHICLE_STATUS_DICT[VRL_STATES.OUT_OF_SERVICE]) & (op_vehicle_df["status"] != G_VEHICLE_STATUS_DICT[VRL_STATES.CHARGING])]
+                utilized_veh_df = op_vehicle_df[(op_vehicle_df["status"] != VRL_STATES.OUT_OF_SERVICE.display_name) & (op_vehicle_df["status"] != VRL_STATES.CHARGING.display_name)]
                 utilization_time = utilized_veh_df["VRL_end_sim_end_time"].sum() - utilized_veh_df["VRL_start_sim_end_time"].sum()
-                unutilized_veh_df = op_vehicle_df[(op_vehicle_df["status"] == G_VEHICLE_STATUS_DICT[VRL_STATES.OUT_OF_SERVICE]) | (op_vehicle_df["status"] == G_VEHICLE_STATUS_DICT[VRL_STATES.CHARGING])]
+                unutilized_veh_df = op_vehicle_df[(op_vehicle_df["status"] == VRL_STATES.OUT_OF_SERVICE.display_name) | (op_vehicle_df["status"] == VRL_STATES.CHARGING.display_name)]
                 unutilized_time = unutilized_veh_df["VRL_end_sim_end_time"].sum() - unutilized_veh_df["VRL_start_sim_end_time"].sum()
-                rev_df = op_vehicle_df[op_vehicle_df["status"].isin([G_VEHICLE_STATUS_DICT[x] for x in G_REVENUE_STATUS])]
+                rev_df = op_vehicle_df[op_vehicle_df["status"].isin([x.display_name for x in G_REVENUE_STATUS])]
                 op_vehicle_revenue_hours = (rev_df["VRL_end_sim_end_time"].sum() - rev_df["VRL_start_sim_end_time"].sum())/3600.0
                 op_ride_per_veh_rev_hours = op_number_pax/op_vehicle_revenue_hours
                 op_ride_per_veh_rev_hours_rq = op_number_users/op_vehicle_revenue_hours
@@ -429,7 +429,7 @@ def standard_evaluation(output_dir, evaluation_start_time = None, evaluation_end
                 op_ride_distance_per_vehicle_distance_no_rel = op_sum_direct_travel_distance / (op_total_km * (1.0 - op_repositioning_vkm/100.0))
 
             # speed
-            driving = op_vehicle_df[op_vehicle_df["status"].isin([G_VEHICLE_STATUS_DICT[i] for i in G_DRIVING_STATUS])]
+            driving = op_vehicle_df[op_vehicle_df["status"].isin([i.display_name for i in G_DRIVING_STATUS])]
             driving_time = driving["end_time"].sum() - driving["start_time"].sum()
             op_avg_velocity = op_total_km/driving_time*3600.0
             op_trip_velocity = trip_direct_distance/op_user_sum_travel_time*3.6

--- a/src/evaluation/temporal.py
+++ b/src/evaluation/temporal.py
@@ -167,7 +167,7 @@ def avg_util_binned(binned_operator_stats, output_dir, op_id, n_vehicles, show=T
     util = []
     last = 0
     bins = list(binned_operator_stats.keys())
-    util_states = [G_VEHICLE_STATUS_DICT[x] for x in G_REVENUE_STATUS]
+    util_states = [x.display_name for x in G_REVENUE_STATUS]
     for t, binned_stats_df in binned_operator_stats.items():
         ts.append(t/3600.0)
         util.append(last)
@@ -202,7 +202,7 @@ def avg_fleet_km_binned(binned_operator_stats, output_dir, op_id, show = True):
     last = 0
     bins = list(binned_operator_stats.keys())
     bin_size = bins[1] - bins[0]
-    driving_states = [G_VEHICLE_STATUS_DICT[x] for x in G_DRIVING_STATUS]
+    driving_states = [x.display_name for x in G_DRIVING_STATUS]
     for t, binned_stats_df in binned_operator_stats.items():
         ts.append(t/3600.0)
         driven_distances.append(last)
@@ -241,8 +241,8 @@ def avg_fleet_driving_speeds_binned(binned_operator_stats, output_dir, op_id, sh
     last_rev = 0
     bins = list(binned_operator_stats.keys())
     bin_size = bins[1] - bins[0]
-    driving_states = [G_VEHICLE_STATUS_DICT[x] for x in G_DRIVING_STATUS]
-    util_states = [G_VEHICLE_STATUS_DICT[x] for x in G_REVENUE_STATUS]
+    driving_states = [x.display_name for x in G_DRIVING_STATUS]
+    util_states = [x.display_name for x in G_REVENUE_STATUS]
     for t, binned_stats_df in binned_operator_stats.items():
         ts.append(t/3600.0)
         driven_speed.append(last_dr)
@@ -301,7 +301,7 @@ def avg_revenue_hours_binned(binned_operator_stats, output_dir, op_id, n_vehicle
     last = 0
     bins = list(binned_operator_stats.keys())
     bin_size = bins[1] - bins[0]
-    util_states = [G_VEHICLE_STATUS_DICT[x] for x in G_REVENUE_STATUS]
+    util_states = [x.display_name for x in G_REVENUE_STATUS]
     for t, binned_stats_df in binned_operator_stats.items():
         ts.append(t/3600.0)
         vrhs.append(last)
@@ -395,7 +395,7 @@ def avg_customers_per_vehicle_revenue_hous_binned(binned_served_customer_stats, 
     bins = list(binned_served_customer_stats.keys())
     bin_size = bins[1] - bins[0]
     differs = False
-    util_states = [G_VEHICLE_STATUS_DICT[x] for x in G_REVENUE_STATUS]
+    util_states = [x.display_name for x in G_REVENUE_STATUS]
     def get_frac_active_cust_time(row):
         rq_time = row[G_RQ_DO] - row[G_RQ_TIME]
         return row["interval_weight"] * bin_size/rq_time

--- a/src/misc/globals.py
+++ b/src/misc/globals.py
@@ -5,6 +5,7 @@ These variables should be referenced for Data Input, Output and Evaluation to gu
 import os
 import json
 from enum import Enum
+from types import DynamicClassAttribute
 
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -465,60 +466,35 @@ G_V_INIT_SOC = "final_soc"
 # Vehicle Status
 # --------------
 class VRL_STATES(Enum):
-    BLOCKED_INIT = -1
-    IDLE = 0
-    BOARDING = 1
-    CHARGING = 2
-    BOARDING_WITH_CHARGING = 3
-    WAITING = 4
-    OUT_OF_SERVICE = 5
-    PLANNED_STOP = 6    # TODO whats that for?
-    ROUTE = 10
-    REPOSITION = 11
-    TO_CHARGE = 12
-    TO_DEPOT = 13
+    BLOCKED_INIT = (-1, "blocked_init_status")
+    IDLE = (0, "idle")
+    BOARDING = (1, "boarding")
+    CHARGING = (2, "charging")
+    BOARDING_WITH_CHARGING = (3, "boarding_with_charging")
+    WAITING = (4, "waiting")
+    OUT_OF_SERVICE = (5, "out_of_service")
+    PLANNED_STOP = (6, "planned_stop")    # TODO whats that for?
+    ROUTE = (10, "route")
+    REPOSITION = (11, "reposition")
+    TO_CHARGE = (12, "to_charge")
+    TO_DEPOT = (13, "to_depot")
+
+    @DynamicClassAttribute
+    def value(self):
+        return self._value_[0]
+
+    @DynamicClassAttribute
+    def display_name(self):
+        return self._value_[1]
+
+    @staticmethod
+    def G_VEHICLE_STATUS_DICT() -> dict:
+        return {status.value: status.display_name for status in VRL_STATES}
 
 G_DRIVING_STATUS = [VRL_STATES.ROUTE, VRL_STATES.REPOSITION, VRL_STATES.TO_CHARGE, VRL_STATES.TO_DEPOT] # [10,11,12,13]
 G_REVENUE_STATUS = [VRL_STATES.BOARDING, VRL_STATES.WAITING, VRL_STATES.ROUTE, VRL_STATES.REPOSITION] # [1, 4, 10, 11]
 G_LAZY_STATUS = [VRL_STATES.WAITING] # [4]     # VRLs not actively planned and dont do anything (i.e. waiting)
 G_LOCK_DURATION_STATUS = [VRL_STATES.BLOCKED_INIT, VRL_STATES.BOARDING, VRL_STATES.BOARDING_WITH_CHARGING] # [-1, 1, 3]
-G_VEHICLE_STATUS_DICT = {}
-G_VEHICLE_STATUS_DICT[VRL_STATES.BLOCKED_INIT] = "blocked_init_status"
-G_VEHICLE_STATUS_DICT[VRL_STATES.IDLE] = "idle"
-G_VEHICLE_STATUS_DICT[VRL_STATES.BOARDING] = "boarding"
-G_VEHICLE_STATUS_DICT[VRL_STATES.CHARGING] = "charging"
-G_VEHICLE_STATUS_DICT[VRL_STATES.BOARDING_WITH_CHARGING] = "boarding_with_charging"
-G_VEHICLE_STATUS_DICT[VRL_STATES.WAITING] = "waiting"
-G_VEHICLE_STATUS_DICT[VRL_STATES.OUT_OF_SERVICE] = "out_of_service"
-G_VEHICLE_STATUS_DICT[VRL_STATES.PLANNED_STOP] = "planned_stop"
-G_VEHICLE_STATUS_DICT[VRL_STATES.ROUTE] = "route"
-G_VEHICLE_STATUS_DICT[VRL_STATES.REPOSITION] = "reposition"
-G_VEHICLE_STATUS_DICT[VRL_STATES.TO_CHARGE] = "to_charge"
-G_VEHICLE_STATUS_DICT[VRL_STATES.TO_DEPOT] = "to_depot"
-
-# G_DRIVING_STATUS = [10,11,12,13,14,15,16,19,20]
-# G_IDLE_BUSY_STATUS = [17,18]
-# G_LAZY_STATUS = [4]     # VRLs not actively planned and dont do anything (i.e. waiting)
-# G_LOCK_DURATION_STATUS = [-1, 1, 3]
-# G_VEHICLE_STATUS_DICT = {}
-# G_VEHICLE_STATUS_DICT[-1] = "blocked_init_status"
-# G_VEHICLE_STATUS_DICT[0] = "idle"
-# G_VEHICLE_STATUS_DICT[1] = "boarding"
-# G_VEHICLE_STATUS_DICT[2] = "charging"
-# G_VEHICLE_STATUS_DICT[3] = "boarding_with_charging"
-# G_VEHICLE_STATUS_DICT[4] = "waiting"
-# G_VEHICLE_STATUS_DICT[5] = "out_of_service"
-# G_VEHICLE_STATUS_DICT[10] = "route"
-# G_VEHICLE_STATUS_DICT[11] = "reposition"
-# G_VEHICLE_STATUS_DICT[12] = "to_charge"
-# G_VEHICLE_STATUS_DICT[13] = "to_depot"
-# G_VEHICLE_STATUS_DICT[14] = "private_en_route"
-# G_VEHICLE_STATUS_DICT[15] = "searching_charging_station"
-# G_VEHICLE_STATUS_DICT[16] = "going_back_no_socket_found"
-# G_VEHICLE_STATUS_DICT[17] = "charging_privately"
-# G_VEHICLE_STATUS_DICT[18] = "charging_at_station"
-# G_VEHICLE_STATUS_DICT[19] = "driving_to_reserved_station"
-# G_VEHICLE_STATUS_DICT[20] = "redirected_to_reserved_station"
 
 # TODO # after ISTTT: define all vehicle states
 


### PR DESCRIPTION
Previously, the globals.py used a separate dictionary named "G_VEHICLE_STATUS_DICT" to hold the names of the individual vehicle states.
The code is simplified using tuples for the values of enum in the VRL_STATES. The value method of the VRL_STATES is overridden to return the state value (first element of the tuple) and the method "display_name" returns the second element of the tuple.