### PR TITLE
Yunfei/fix sumo cosim

### DIFF
--- a/src/coupling/SUMO/SUMOFleetPyServer.py
+++ b/src/coupling/SUMO/SUMOFleetPyServer.py
@@ -21,7 +21,7 @@ from src.misc.init_modules import load_simulation_environment
 import src.misc.config as config
 from src.misc.globals import *
 import src.evaluation.standard as eval
-from run_examples import run_scenarios
+from run_scenarios import run_scenarios
 import random
 import time
 

--- a/src/coupling/SUMO/SUMOFleetPyServer.py
+++ b/src/coupling/SUMO/SUMOFleetPyServer.py
@@ -17,6 +17,7 @@ import time
 import numpy as np
 import pathlib
 from src.coupling.SUMO.SUMOcontrolledSim import SUMOcontrolledSim
+from src.coupling.SUMO.sumocfg_utils import merge_additional_files
 from src.misc.init_modules import load_simulation_environment
 import src.misc.config as config
 from src.misc.globals import *
@@ -199,7 +200,11 @@ class SUMOFleetPyServer():
         sumoCmd = [self.sumo_binary, "-c", self.sumo_config_path ,
                 "--collision.action","warn",
                 "--begin",str(self.fp_sim_env.scenario_parameters.get(G_SIM_START_TIME)),
-                 "-a",EdgeDataCfgPath,
+                 # SUMO's -a REPLACES the sumocfg's <additional-files> rather
+                 # than extending it, so passing EdgeDataCfgPath alone would
+                 # silently drop the scenario's traffic-light programs, WAUT
+                 # switching and public transport. Merge them back in.
+                 "-a",merge_additional_files(self.sumo_config_path, EdgeDataCfgPath),
                 "--step-length","1",
                 "--tripinfo-output",TripInfoPath,
                 "--vehroute-output",vehRoutePath,

--- a/src/coupling/SUMO/sumocfg_utils.py
+++ b/src/coupling/SUMO/sumocfg_utils.py
@@ -1,0 +1,48 @@
+"""Helpers for combining a .sumocfg's own settings with the ones the co-sim
+server adds on the command line.
+
+SUMO's command-line options *override* the configuration file rather than
+extending it. For scalar options that is the intent, but for the
+``--additional-files`` list it means that passing ``-a`` with a generated file
+silently discards everything the scenario declared: traffic-light programs,
+WAUT switching, public-transport stops and schedules. The simulation still runs
+and still produces output, which makes the mistake easy to miss.
+
+Kept free of FleetPy and traci imports so it can be unit-tested on its own.
+"""
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from typing import List
+
+
+def additional_files_from_sumocfg(sumocfg_path: str) -> List[str]:
+    """Absolute paths of the additional files a .sumocfg declares.
+
+    Relative entries are resolved against the config's own directory, which is
+    how SUMO itself interprets them.
+    """
+    base = os.path.dirname(os.path.abspath(sumocfg_path))
+    root = ET.parse(sumocfg_path).getroot()
+    files: List[str] = []
+    for el in root.iter("additional-files"):
+        for part in el.get("value", "").split(","):
+            part = part.strip()
+            if not part:
+                continue
+            files.append(
+                part if os.path.isabs(part) else os.path.normpath(os.path.join(base, part))
+            )
+    return files
+
+
+def merge_additional_files(sumocfg_path: str, *extra: str) -> str:
+    """Value for ``-a`` that keeps the scenario's additional files and appends
+    `extra`, preserving order and dropping duplicates.
+    """
+    merged: List[str] = []
+    for path in list(additional_files_from_sumocfg(sumocfg_path)) + list(extra):
+        if path and path not in merged:
+            merged.append(path)
+    return ",".join(merged)


### PR DESCRIPTION
Two independent bugs in SUMOFleetPyServer.py, one commit each.

1. SUMOFleetPyServer cannot be imported (f405e07)

Line 24 imports run_scenarios from run_examples, but run_examples.py moved into studies/example_study/ in 55c9d04 and the import was never updated.


python -c "import src.coupling.SUMO.SUMOFleetPyServer"
ModuleNotFoundError: No module named 'run_examples'
Repointed at run_scenarios.py, which is where the symbol lives and what studies/example_study/run_examples.py itself imports.

2. The co-sim silently drops every scenario's additional files (0ec35c8)

SUMO's -a replaces the <additional-files> list from the sumocfg rather than extending it. setup_sumo_simulation() passes -a with its generated edgeData config, so traffic-light programs, WAUT switching, PT stops and schedules are all discarded.

Nothing fails: the simulation runs to completion and produces plausible output, just with no signal control and no transit. Reproduce on any scenario with additional files:


sumo -c scenario.sumocfg -a generated.add.xml --save-configuration effective.cfg
effective.cfg lists only generated.add.xml.

New sumocfg_utils.merge_additional_files() reads what the sumocfg declares, resolves paths relative to the config's directory as SUMO does, and appends the generated file, preserving order and dropping duplicates. Kept free of FleetPy and traci imports so it can be tested standalone.

Verified on the Ingolstadt scenario over TraCI: 123 traffic lights load after the fix, 0 before.

Branched off current dev/merge_to_master. Touches only the two files; no study or data changes.