### PR TITLE
network_from_sumo: support networks built with --no-internal-links

### DIFF
--- a/src/preprocessing/networks/network_from_sumo.py
+++ b/src/preprocessing/networks/network_from_sumo.py
@@ -115,20 +115,45 @@ def create_nodes_and_edges_from_xml(xmlfile, allowed_modes="all"):
     
                 
     #Add Connecting edges (within intersections)
+    # Index the edge elements once. Looking them up with root_node.findall("edge")
+    # inside the connection loop is O(#connections * #edges) -- on a city network
+    # (~38k connections, ~22k edges) that is ~850M iterations.
+    edge_elements_by_id = {edge.get("id"): edge for edge in root_node.findall("edge")}
+
     for connection in tqdm(root_node.findall('connection'),desc="Add Connecting edges (within intersections)"):
         fromEdge = connection.get('from')
         toEdge = connection.get('to')
         if fromEdge not in edges.keys() or toEdge not in edges.keys() or ":" in fromEdge or ":" in toEdge:
             continue
+
+        from_node_index = nodes[f"E_{fromEdge}"]["node_index"]
+        to_node_index = nodes[f"S_{toEdge}"]["node_index"]
+        edge_connection = f"i_{fromEdge}_{toEdge}"
+
         internalEdge_id = connection.get("via")
+        if internalEdge_id is None:
+            # Network built with netconvert --no-internal-links: connections carry no
+            # "via" and the net holds no internal edges. Without a connector edge here
+            # every SUMO edge stays an isolated two-node component, so no request can
+            # ever be routed. E_fromEdge and S_toEdge are the same junction, hence a
+            # zero-length connector. The leading ":" marks it internal so the coupling's
+            # _transform_route_fp_to_sumo() drops it from the SUMO route instead of
+            # sending a synthetic edge id to SUMO (turns are implicit at junctions).
+            connector_id = f":c_{fromEdge}__{toEdge}"
+            edges[connector_id] = {"from_node" : from_node_index, "to_node" : to_node_index, "distance" : 0.0, "travel_time" : 0.0, "source_edge_id" : connector_id, "number_of_usable_lanes":1,"connecting_edges":edge_connection}
+            continue
+
         if "_" in internalEdge_id:
             last_underscore_index = internalEdge_id.rfind('_') 
             if last_underscore_index != -1:
                 internalEdge_id= internalEdge_id[:last_underscore_index]
 
-        for edge_element in root_node.findall("edge"): #find internal edge element for id
-            if edge_element.get("id")==internalEdge_id:
-                break
+        edge_element = edge_elements_by_id.get(internalEdge_id)
+        if edge_element is None:
+            # Previously the search loop left edge_element pointing at the last edge of
+            # the network when no id matched, so the connector silently got that
+            # unrelated edge's length and speed.
+            continue
         
         ## Get average speed and length of internal lanes
         internal_lanes_speeds = []
@@ -153,9 +178,6 @@ def create_nodes_and_edges_from_xml(xmlfile, allowed_modes="all"):
             internal_lanes_length_avg = round(internal_lanes_length_avg,1)
         else:
             continue   
-        edge_connection = f"i_{fromEdge}_{toEdge}"
-        from_node_index = nodes[f"E_{fromEdge}"]["node_index"]
-        to_node_index = nodes[f"S_{toEdge}"]["node_index"]
         edges[internalEdge_id] = {"from_node" : from_node_index, "to_node" : to_node_index, "distance" : internal_lanes_length_avg, "travel_time" : min_travel_time, "source_edge_id" : internalEdge_id, "number_of_usable_lanes":internal_lanes_count,"connecting_edges":edge_connection}
   
 


### PR DESCRIPTION
## Problem

`network_from_sumo.py` cannot convert a network that `netconvert` built with
`--no-internal-links`. It aborts with:

```
TypeError: argument of type 'NoneType' is not a container or iterable
  network_from_sumo.py:124, in create_nodes_and_edges_from_xml
      if "_" in internalEdge_id:
```

Such a network holds no internal edges, so its `<connection>` elements carry no `via`
attribute and `connection.get("via")` returns `None`.

### Minimal reproduction

A two-edge network with one connection and no internal links is enough:

```xml
<net version="1.16">
    <edge id="A" from="n1" to="n2" priority="1">
        <lane id="A_0" index="0" speed="13.89" length="100.00" shape="0,0 100,0"/>
    </edge>
    <edge id="B" from="n2" to="n3" priority="1">
        <lane id="B_0" index="0" speed="13.89" length="100.00" shape="100,0 200,0"/>
    </edge>
    <junction id="n1" type="dead_end"  x="0"   y="0" incLanes=""    intLanes="" shape="0,0"/>
    <junction id="n2" type="priority"  x="100" y="0" incLanes="A_0" intLanes="" shape="100,0"/>
    <junction id="n3" type="dead_end"  x="200" y="0" incLanes="B_0" intLanes="" shape="200,0"/>
    <connection from="A" to="B" fromLane="0" toLane="0" dir="s" state="M"/>
</net>
```

```
python network_from_sumo.py mini.net.xml -n mini -a "passenger,taxi"
```

## Why guarding the `None` is not enough

The connection loop is what creates the connector edges between the per-edge start/end
node pairs. Simply skipping connections without a `via` leaves every SUMO edge as an
isolated two-node component, so **no request can be routed at all** — the simulation
runs and serves nothing.

Without internal links, the end node of the incoming edge and the start node of the
outgoing edge are the same junction, so a **zero-length connector** is the correct
representation. Its id gets a leading `:` so that
`SUMOFleetPyServer._transform_route_fp_to_sumo()` drops it from the route sent to SUMO —
that function already skips ids starting with `:`. Turns are implicit at junctions in
SUMO, so a synthetic edge id would otherwise be rejected.

## Two further problems in the same loop

- **Leaked loop variable.** The `#find internal edge element for id` loop left
  `edge_element` pointing at the *last* `<edge>` of the network when no id matched,
  so the connector silently got that unrelated edge's length and speed. It is now a dict
  lookup that skips on a miss. This is the only intended behaviour change for networks
  that do have internal links.
- **Quadratic lookup.** That search re-ran `root_node.findall("edge")` once per
  connection, i.e. `O(#connections * #edges)` — about 850M iterations on a city network
  (~38k connections, ~22k edges). The edge elements are now indexed once up front.

## Verification

- The minimal network above converts instead of crashing, and the resulting graph is
  connected (`A: 0->1`, `:c_A__B: 1->2`, `B: 2->3`).
- A 34 MB `--no-internal-links` network of Zurich (22453 edges, 37681 connections)
  converts in **35 s** to 43416 nodes / 56350 edges with 34642 zero-length connectors,
  **92.9 %** of nodes in the largest strongly connected component.
- **Regression:** for two networks *with* internal links, the returned `nodes` and
  `edges` dicts are identical to those produced by the module before this change
  (compared object-by-object against the pre-patch version).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
