### PR TITLE
SUMO coupling: make vehicle position feedback work in mesoscopic mode

### DIFF
--- a/src/coupling/SUMO/SUMOFleetPyServer.py
+++ b/src/coupling/SUMO/SUMOFleetPyServer.py
@@ -444,7 +444,6 @@ class SUMOFleetPyServer():
 
                                 except:
                                     LOG.warning(f"Vehicle {sumo_vid} could not be rerouted")
-                                    breakpoint()
                     else:
                         LOG.debug(f"Vehicle {sumo_vid} is Loaded and in Network and SumoRoute {sumoRoute} is current Route {currentRoute}")
                         pass 
@@ -633,15 +632,24 @@ class SUMOFleetPyServer():
             ## A) Vehicle Moving on the Road --> Get Update 
             if str(sumo_vid) in current_sumo_vehicle_ids_set:
                 LOG.debug("Vehicle is in IDList and position should be updated")
-                currentLane = traci.vehicle.getLaneID(str(sumo_vid))
-                laneLength = traci.lane.getLength(currentLane)
-                currentLanePosition = traci.vehicle.getLanePosition(str(sumo_vid)) #returns something like: 20.267898023103246 (Other format needed?!)
-                frac_position = currentLanePosition/laneLength
-                currentEdge = traci.lane.getEdgeID(currentLane)
-                if self.g_sumo_edge_id_to_fs_edge.get(currentEdge) is not None:
-                    o_node, d_node = self.g_sumo_edge_id_to_fs_edge[currentEdge]
-                    CurrentPosition = (o_node, d_node, frac_position)
-                    vehicle_to_position_dict[opid_vid_tuple] = CurrentPosition
+                # Vehicles have no lane in the mesoscopic model: traci.vehicle.getLaneID()
+                # returns "" there, which makes traci.lane.getLength() raise and aborts the
+                # coupling. Take the edge from getRoadID() instead and its length from the
+                # network tables, both of which are available in micro and in meso.
+                currentEdge = traci.vehicle.getRoadID(str(sumo_vid))
+                fs_edge = self.g_sumo_edge_id_to_fs_edge.get(currentEdge)
+                if fs_edge is not None and currentEdge and not currentEdge.startswith(":"):
+                    edgeLength = self.g_fs_edge_to_len.get(fs_edge)
+                    try:
+                        currentLanePosition = traci.vehicle.getLanePosition(str(sumo_vid))
+                    except traci.exceptions.TraCIException:
+                        currentLanePosition = 0.0
+                    if edgeLength and edgeLength > 0:
+                        frac_position = min(max(currentLanePosition / edgeLength, 0.0), 1.0)
+                    else:
+                        frac_position = 0.000001
+                    o_node, d_node = fs_edge
+                    vehicle_to_position_dict[opid_vid_tuple] = (o_node, d_node, frac_position)
                 else:
                     LOG.debug(f"Edge {currentEdge} not known in FP, no update this timestep")
 


### PR DESCRIPTION
## Problem

Two independent defects in `SUMOFleetPyServer.py` that each **stop** a coupled run rather
than degrade it.

### 1. Position feedback is impossible in the mesoscopic model

Vehicles have no lane in SUMO's mesoscopic model. `traci.vehicle.getLaneID()` returns `""`
for them, and `traci.lane.getLength("")` raises a `TraCIException`, so
`_get_current_vehicle_positions()` aborts on the first meso vehicle — and with it the whole
co-simulation. Meso is the only practical choice for a city-scale background traffic
scenario, so the coupling is effectively micro-only today.

The edge now comes from `traci.vehicle.getRoadID()` and its length from
`self.g_fs_edge_to_len`, both available in micro *and* meso. `g_fs_edge_to_len` is keyed by
the `(from_node, to_node)` tuple and filled from the same `edges.csv` `distance` column
that `network_from_sumo.py` writes from the SUMO lane length — so the value is the one the
old code read off the lane, and the microscopic path is unchanged.

Details preserved from the old code:

- Vehicles on an internal edge are still skipped: `getRoadID()` returns an id starting with
  `:`, which is not in `g_sumo_edge_id_to_fs_edge` anyway.
- `getLanePosition()` is wrapped, because it can still fail while a vehicle is teleporting.
- The fraction is clamped to `[0, 1]`, and the zero-length fallback uses `0.000001`, which
  is the value this file already uses for pending vehicles a few lines further down.

### 2. Stray `breakpoint()` in the reroute-failure handler

```python
except:
    LOG.warning(f"Vehicle {sumo_vid} could not be rerouted")
    breakpoint()
```

This drops an unattended run into `pdb` on stdin and hangs it indefinitely. The warning
right next to it already reports the condition.

## Relation to #58

This touches the same file as #58 but different lines, so the two do not conflict. #58's
fixes are not included here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
